### PR TITLE
fix(tazblog): Explicitly allow substitutes for the blog

### DIFF
--- a/services/tazblog/default.nix
+++ b/services/tazblog/default.nix
@@ -4,9 +4,13 @@
 
 { writeShellScriptBin, haskell }:
 
-let tazblog = haskell.packages.ghc865.callPackage ./tazblog.nix {};
-in writeShellScriptBin "tazblog" ''
-  export PORT=8000
-  export RESOURCE_DIR=${./static}
-  exec ${tazblog}/bin/tazblog
-''
+let
+  tazblog = haskell.packages.ghc865.callPackage ./tazblog.nix {};
+  wrapper =  writeShellScriptBin "tazblog" ''
+    export PORT=8000
+    export RESOURCE_DIR=${./static}
+    exec ${tazblog}/bin/tazblog
+  '';
+in wrapper.overrideAttrs(_: {
+  allowSubstitutes = true;
+})


### PR DESCRIPTION
Not entirely sure which part of the setup set this to 'false', but
this is potentially the key for why tazblog ends up being rebuilt all
the time.