### PR TITLE
Switch Emacs terminals over to libvterm

### DIFF
--- a/tools/emacs-pkgs/term-switcher/term-switcher.el
+++ b/tools/emacs-pkgs/term-switcher/term-switcher.el
@@ -1,72 +1,55 @@
-;;; term-switcher.el --- Easily switch between open X11 terminals
+;;; term-switcher.el --- Easily switch between open vterms
 ;;
 ;; Copyright (C) 2019 Google Inc.
 ;;
 ;; Author: Vincent Ambo <tazjin@google.com>
-;; Version: 1.0
+;; Version: 1.1
 ;; Package-Requires: (dash ivy s)
 ;;
 ;;; Commentary:
 ;;
 ;; This package adds a function that lets users quickly switch between
-;; different open X11 terminals using ivy.
-;;
-;; It is primarily intended to be used by EXWM users who use graphical
-;; terminals inside of Emacs.
-;;
-;; Users MUST configure the group `term-switcher' and can then bind
-;; `ts/switch-to-terminal' to an appropriate key.
+;; different open vterms via ivy.
 
 (require 'dash)
 (require 'ivy)
 (require 's)
 
 (defgroup term-switcher nil
-  "Customization options for configuring `term-switcher' with the
-  user's terminal emulator of choice.")
+  "Customization options `term-switcher'.")
 
-(defcustom term-switcher-program "gnome-terminal"
-  "X11 terminal application to use."
+(defcustom term-switcher-buffer-prefix "vterm<"
+  "String prefix for vterm terminal buffers. For example, if you
+  set your titles to match `vterm<...>' a useful prefix might be
+  `vterm<'."
   :type '(string)
   :group 'term-switcher)
 
-(defcustom term-switcher-buffer-prefix "Term"
-  "String prefix for X11 terminal buffers. For example, if your
-  EXWM configuration renames X11 terminal buffers to
-  `Term</foo/bar>' you might want to use `Term' as the matching
-  prefix."
-  :type '(string)
-  :group 'term-switcher)
-
-(defun ts/run-terminal-program ()
-  (message "Starting %s..." term-switcher-program)
-  (start-process-shell-command term-switcher-program nil term-switcher-program))
-
-(defun ts/open-or-create-terminal-buffer (buffer-name)
-  "Switch to the buffer with BUFFER-NAME or create a new buffer
-  running the configured X11 terminal."
+(defun ts/open-or-create-vterm (buffer-name)
+  "Switch to the buffer with BUFFER-NAME or create a new vterm
+  buffer."
   (let ((buffer (get-buffer buffer-name)))
     (if (not buffer)
-        (ts/run-terminal-program)
+        (vterm)
       (switch-to-buffer buffer))))
 
-(defun ts/is-terminal-buffer (buffer)
-  "Determine whether BUFFER runs an X11 terminal."
-  (and (equal 'exwm-mode (buffer-local-value 'major-mode buffer))
-       (s-starts-with? term-switcher-buffer-prefix (buffer-name buffer))))
+(defun ts/is-vterm-buffer (buffer)
+  "Determine whether BUFFER runs a vterm."
+  (equal 'vterm-mode (buffer-local-value 'major-mode buffer)))
 
 (defun ts/switch-to-terminal ()
-  "Switch to an X11 terminal buffer, or create a new one."
+  "Switch to an existing vterm buffer or create a new one."
+
   (interactive)
   (let ((terms (-map #'buffer-name
-                     (-filter #'ts/is-terminal-buffer (buffer-list)))))
+                     (-filter #'ts/is-vterm-buffer (buffer-list)))))
     (if terms
-        (ivy-read "Switch to terminal buffer: "
-                  (cons "New terminal" terms)
+        (ivy-read "Switch to vterm: "
+                  (cons "New vterm" terms)
                   :caller 'ts/switch-to-terminal
                   :preselect (s-concat "^" term-switcher-buffer-prefix)
                   :require-match t
-                  :action #'ts/open-or-create-terminal-buffer)
-      (ts/run-terminal-program))))
+                  :action #'ts/open-or-create-vterm)
+      (vterm))))
 
 (provide 'term-switcher)

--- a/tools/emacs/config/init.el
+++ b/tools/emacs/config/init.el
@@ -73,6 +73,19 @@
 (use-package pg)
 (use-package restclient)
 
+(use-package vterm
+  :config (progn
+            (setq vterm-shell "/usr/bin/fish")
+            (setq vterm-exit-functions
+                  (lambda (&rest _) (kill-buffer (current-buffer))))
+            (setq vterm-set-title-functions
+                  (lambda (title)
+                    (rename-buffer
+                     (generate-new-buffer-name
+                      (format "vterm<%s>"
+                              (s-trim-left
+                               (s-chop-prefix "fish" title)))))))))
+
 ;;
 ;; Packages providing language-specific functionality
 ;;

--- a/tools/emacs/default.nix
+++ b/tools/emacs/default.nix
@@ -73,6 +73,7 @@ let
     transient
     use-package
     uuidgen
+    vterm
     web-mode
     websocket
     which-key


### PR DESCRIPTION
This moves the terminals inside of my Emacs from being `gnome-terminal` instances under EXWM over to [emacs-libvterm](https://github.com/akermu/emacs-libvterm).

This incredible package embeds a fully featured terminal emulator (based on `libvterm`) into Emacs with the killer feature of being able to switch a terminal buffer to read-only text mode and use normal Emacs selection commands.

This is something I've wanted for a long time and that `ansi-term` etc. just weren't good enough for!