### PR TITLE
Import the Go binary 'buildpacks/pack'

### DIFF
--- a/third_party/default.nix
+++ b/third_party/default.nix
@@ -77,7 +77,11 @@ let
 
 in exposed // {
   callPackage = nixpkgs.lib.callPackageWith exposed;
+
   # Provide the source code of nixpkgs, but do not provide an imported
   # version of it.
   nixpkgsSrc = stableSrc;
+
+  # Surface these things from within the depths of the tree ...
+  pack = pkgs.third_party.gopkgs."github.com".buildpacks.pack.cmd.pack;
 }

--- a/third_party/gopkgs/github.com/BurntSushi/toml/default.nix
+++ b/third_party/gopkgs/github.com/BurntSushi/toml/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/BurntSushi/toml";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "BurntSushi";
+    repo = "toml";
+    rev = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005";
+    sha256 = "1fjdwwfzyzllgiwydknf1pwjvy49qxfsczqx5gz3y0izs7as99j6";
+  };
+}

--- a/third_party/gopkgs/github.com/Masterminds/semver/default.nix
+++ b/third_party/gopkgs/github.com/Masterminds/semver/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/Masterminds/semver";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "Masterminds";
+    repo = "semver";
+    rev = "910aa146bd66780c2815d652b92a7fc5331e533c";
+    sha256 = "1b3956cdk0ps1vqjf0al05xzw8b61rvswk59qmjwqypkqp3a2n8c";
+  };
+}

--- a/third_party/gopkgs/github.com/apex/log/default.nix
+++ b/third_party/gopkgs/github.com/apex/log/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/apex/log";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "apex";
+    repo = "log";
+    rev = "baa5455d10123171ef1951381610c51ad618542a";
+    sha256 = "157g78m239fsy0dmfamcsmwag6ys8yhdy509h9x5k4zknlbjybia";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".pkg.errors
+  ];
+}

--- a/third_party/gopkgs/github.com/buildpacks/imgutil/default.nix
+++ b/third_party/gopkgs/github.com/buildpacks/imgutil/default.nix
@@ -1,0 +1,28 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/buildpacks/imgutil";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "buildpacks";
+    repo = "imgutil";
+    rev = "dc184e0d403baee6564954e619d588754105e791";
+    sha256 = "1i6knq0cd28k06spkryv76wn3wyaafi675k3q4fazhpk9njb9nfl";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".docker.docker.api.types
+    gopkgs."github.com".docker.docker.api.types.container
+    gopkgs."github.com".docker.docker.client
+    gopkgs."github.com".google.go-containerregistry.pkg.name
+    gopkgs."github.com".google.go-containerregistry.pkg.authn
+    gopkgs."github.com".google.go-containerregistry.pkg.v1
+    gopkgs."github.com".google.go-containerregistry.pkg.v1.mutate
+    gopkgs."github.com".google.go-containerregistry.pkg.v1.random
+    gopkgs."github.com".google.go-containerregistry.pkg.v1.remote
+    gopkgs."github.com".google.go-containerregistry.pkg.v1.tarball
+    gopkgs."github.com".google.go-containerregistry.pkg.v1.types
+    gopkgs."github.com".google.go-containerregistry.pkg.v1.remote.transport
+    gopkgs."github.com".pkg.errors
+    gopkgs."golang.org".x.sync.singleflight
+  ];
+}

--- a/third_party/gopkgs/github.com/buildpacks/lifecycle/default.nix
+++ b/third_party/gopkgs/github.com/buildpacks/lifecycle/default.nix
@@ -1,0 +1,25 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/buildpacks/lifecycle";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "buildpacks";
+    repo = "lifecycle";
+    rev = "b9dc1bd64e7f9c001139c80cbfa884951599451e";
+    sha256 = "0gr7qh74g7cp0mbj6dmn48j26sk4cra2dbipm5hvb8bmhmz1q106";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".BurntSushi.toml
+    gopkgs."github.com".apex.log
+    gopkgs."github.com".buildpacks.imgutil
+    gopkgs."github.com".buildpacks.imgutil.local
+    gopkgs."github.com".buildpacks.imgutil.remote
+    gopkgs."github.com".docker.docker.client
+    gopkgs."github.com".google.go-containerregistry.pkg.authn
+    gopkgs."github.com".google.go-containerregistry.pkg.name
+    gopkgs."github.com".heroku.color
+    gopkgs."github.com".pkg.errors
+    gopkgs."golang.org".x.sync.errgroup
+  ];
+}

--- a/third_party/gopkgs/github.com/buildpacks/pack/default.nix
+++ b/third_party/gopkgs/github.com/buildpacks/pack/default.nix
@@ -1,0 +1,37 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/buildpacks/pack";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "buildpacks";
+    repo = "pack";
+    rev = "508158aa547ed2f580aa8eee808f035bdc8b1806";
+    sha256 = "0zqmf02b13nrwkyn05jmcxpxwz6r1aa0dh05pwc1pzpw1w4qxad3";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".BurntSushi.toml
+    gopkgs."github.com".Masterminds.semver
+    gopkgs."github.com".apex.log
+    gopkgs."github.com".buildpacks.imgutil
+    gopkgs."github.com".buildpacks.imgutil.local
+    gopkgs."github.com".buildpacks.imgutil.remote
+    gopkgs."github.com".buildpacks.lifecycle
+    gopkgs."github.com".buildpacks.lifecycle.auth
+    gopkgs."github.com".docker.docker.api.types
+    gopkgs."github.com".docker.docker.api.types.container
+    gopkgs."github.com".docker.docker.client
+    gopkgs."github.com".docker.docker.pkg.ioutils
+    gopkgs."github.com".docker.docker.pkg.jsonmessage
+    gopkgs."github.com".docker.docker.pkg.stdcopy
+    gopkgs."github.com".docker.go-connections.nat
+    gopkgs."github.com".google.go-containerregistry.pkg.authn
+    gopkgs."github.com".google.go-containerregistry.pkg.name
+    gopkgs."github.com".google.go-containerregistry.pkg.v1
+    gopkgs."github.com".google.go-containerregistry.pkg.v1.tarball
+    gopkgs."github.com".heroku.color
+    gopkgs."github.com".mitchellh.ioprogress
+    gopkgs."github.com".pkg.errors
+    gopkgs."github.com".spf13.cobra
+  ];
+}

--- a/third_party/gopkgs/github.com/containerd/containerd/default.nix
+++ b/third_party/gopkgs/github.com/containerd/containerd/default.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/containerd/containerd";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "containerd";
+    repo = "containerd";
+    rev = "5473637144496250e4221c9103568d96c33ca29b";
+    sha256 = "157km87ppmmz22akcdx915nq6xpacgmwr2343wqa7ph7k3m5nrjj";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".pkg.errors
+    gopkgs."google.golang.org".grpc.codes
+    gopkgs."google.golang.org".grpc.status
+  ];
+}

--- a/third_party/gopkgs/github.com/docker/cli/default.nix
+++ b/third_party/gopkgs/github.com/docker/cli/default.nix
@@ -1,0 +1,18 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/docker/cli";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "docker";
+    repo = "cli";
+    rev = "ebca1413117a3fcb81c89d6be226dcec74e5289f";
+    sha256 = "07x8fpnw5m94v9432z86hv1p3b4cj2b8vlacfgb67mka845gvazm";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".docker.docker.pkg.homedir
+    gopkgs."github.com".docker.docker-credential-helpers.client
+    gopkgs."github.com".docker.docker-credential-helpers.credentials
+    gopkgs."github.com".pkg.errors
+  ];
+}

--- a/third_party/gopkgs/github.com/docker/distribution/default.nix
+++ b/third_party/gopkgs/github.com/docker/distribution/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/docker/distribution";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "docker";
+    repo = "distribution";
+    rev = "a8371794149d1d95f1e846744b05c87f2f825e5a";
+    sha256 = "159rdbawff5cnhlizhhmwaj7g71m7ffc8n6il0ns7mndk6r3s961";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".opencontainers.go-digest
+  ];
+}

--- a/third_party/gopkgs/github.com/docker/docker-credential-helpers/default.nix
+++ b/third_party/gopkgs/github.com/docker/docker-credential-helpers/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/docker/docker-credential-helpers";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "docker";
+    repo = "docker-credential-helpers";
+    rev = "f78081d1f7fef6ad74ad6b79368de6348386e591";
+    sha256 = "1gzvvzis2ba8d5zl4hiarnplcyr11jag2xyn1jp50daqigkiymf8";
+  };
+}

--- a/third_party/gopkgs/github.com/docker/docker/default.nix
+++ b/third_party/gopkgs/github.com/docker/docker/default.nix
@@ -1,0 +1,30 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/docker/docker";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "docker";
+    repo = "docker";
+    rev = "3452f136aa680530ca40c03b8f0f9bd19fce056c";
+    sha256 = "1sbf2sj8n2217rk4822wndi0k4qaqmywqjcv62ryljdcfz3w39zg";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".containerd.containerd.errdefs
+    gopkgs."github.com".docker.distribution.reference
+    gopkgs."github.com".docker.distribution.registry.api.errcode
+    gopkgs."github.com".docker.go-connections.nat
+    gopkgs."github.com".docker.go-connections.sockets
+    gopkgs."github.com".docker.go-connections.tlsconfig
+    gopkgs."github.com".docker.go-units
+    gopkgs."github.com".gogo.protobuf.proto
+    gopkgs."github.com".morikuni.aec
+    gopkgs."github.com".opencontainers.go-digest
+    gopkgs."github.com".opencontainers.image-spec.specs-go.v1
+    gopkgs."github.com".pkg.errors
+    gopkgs."github.com".sirupsen.logrus
+    gopkgs."golang.org".x.sys.unix
+    gopkgs."google.golang.org".grpc.codes
+    gopkgs."google.golang.org".grpc.status
+  ];
+}

--- a/third_party/gopkgs/github.com/docker/go-connections/default.nix
+++ b/third_party/gopkgs/github.com/docker/go-connections/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/docker/go-connections";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "docker";
+    repo = "go-connections";
+    rev = "f2a43445ca32a74e9855ddf9f84d7f9cedde55f9";
+    sha256 = "10abbr8fhfd95zjbkk4k62irfswvvahihk5wgzacd9v1d9h7vv9k";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".pkg.errors
+  ];
+}

--- a/third_party/gopkgs/github.com/docker/go-units/default.nix
+++ b/third_party/gopkgs/github.com/docker/go-units/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/docker/go-units";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "docker";
+    repo = "go-units";
+    rev = "519db1ee28dcc9fd2474ae59fca29a810482bfb1";
+    sha256 = "0k8gja8ql4pqg5rzmqvka42vjfs6rzablak87whcnqba6qxpimvz";
+  };
+}

--- a/third_party/gopkgs/github.com/gogo/protobuf/default.nix
+++ b/third_party/gopkgs/github.com/gogo/protobuf/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/gogo/protobuf";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "gogo";
+    repo = "protobuf";
+    rev = "5628607bb4c51c3157aacc3a50f0ab707582b805";
+    sha256 = "0x77x64sxjgfhmbijqfzmj8h4ar25l2w97h01q3cqs1wk7zfnkhp";
+  };
+}

--- a/third_party/gopkgs/github.com/google/go-containerregistry/default.nix
+++ b/third_party/gopkgs/github.com/google/go-containerregistry/default.nix
@@ -1,0 +1,17 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/google/go-containerregistry";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "google";
+    repo = "go-containerregistry";
+    rev = "2f2425524973dd16acfd41b0c4ff4a9aee16b043";
+    sha256 = "16ic58m8ghjsidax8x7y8llms20hm43ac3pj8afpd112m7kkvp03";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".docker.cli.cli.config
+    gopkgs."github.com".docker.cli.cli.config.types
+    gopkgs."golang.org".x.sync.errgroup
+  ];
+}

--- a/third_party/gopkgs/github.com/heroku/color/default.nix
+++ b/third_party/gopkgs/github.com/heroku/color/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/heroku/color";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "heroku";
+    repo = "color";
+    rev = "e220b10c343a04cf4de0fcf7eb58dc0648430081";
+    sha256 = "05yrgmhss7iynkyj7kpdqfic5kxcnv35m6ff3c3c0s69r65h6paw";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".mattn.go-colorable
+  ];
+}

--- a/third_party/gopkgs/github.com/mattn/go-colorable/default.nix
+++ b/third_party/gopkgs/github.com/mattn/go-colorable/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/mattn/go-colorable";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "mattn";
+    repo = "go-colorable";
+    rev = "98ec13f34aabf44cc914c65a1cfb7b9bc815aef1";
+    sha256 = "1yxcz08kminqr1221zxpibnbzfcgs3fafin0z9zqb3gqvf74jywz";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".mattn.go-isatty
+  ];
+}

--- a/third_party/gopkgs/github.com/mattn/go-isatty/default.nix
+++ b/third_party/gopkgs/github.com/mattn/go-isatty/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/mattn/go-isatty";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "mattn";
+    repo = "go-isatty";
+    rev = "31745d66dd679ac0ac4f8d3ecff168fce6170c6a";
+    sha256 = "0h671sv7hfprja495kavazkalkx7xzaqksjh13brcnwq67ijrali";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."golang.org".x.sys.unix
+  ];
+}

--- a/third_party/gopkgs/github.com/mitchellh/ioprogress/default.nix
+++ b/third_party/gopkgs/github.com/mitchellh/ioprogress/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/mitchellh/ioprogress";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "mitchellh";
+    repo = "ioprogress";
+    rev = "6a23b12fa88ea53e63d9b49f148fe6b29c30af6d";
+    sha256 = "1fcfwi5fzv17iahif42y7dhjfnjwkslk03zb9cniw42wyiwhj3jk";
+  };
+}

--- a/third_party/gopkgs/github.com/morikuni/aec/default.nix
+++ b/third_party/gopkgs/github.com/morikuni/aec/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/morikuni/aec";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "morikuni";
+    repo = "aec";
+    rev = "39771216ff4c63d11f5e604076f9c45e8be1067b";
+    sha256 = "1qaqh0lk9wrqgff0yrxnbznvmwyhdxy3g9b2hjpazp5bw4nj0dp7";
+  };
+}

--- a/third_party/gopkgs/github.com/opencontainers/go-digest/default.nix
+++ b/third_party/gopkgs/github.com/opencontainers/go-digest/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/opencontainers/go-digest";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "opencontainers";
+    repo = "go-digest";
+    rev = "e9a29da4f419356054dd9f43b5a1b2f403cefcbc";
+    sha256 = "1cdh2jvsn7y95a7i9j0m5rk1prhkzsddir8wr5g8v2cv87sl0gcj";
+  };
+}

--- a/third_party/gopkgs/github.com/opencontainers/image-spec/default.nix
+++ b/third_party/gopkgs/github.com/opencontainers/image-spec/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/opencontainers/image-spec";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "opencontainers";
+    repo = "image-spec";
+    rev = "775207bd45b6cb8153ce218cc59351799217451f";
+    sha256 = "02nd0bmkcr9mcnw7dii5s4k5n7labgwqgrr542wp1m4k9i5cblhs";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".opencontainers.go-digest
+  ];
+}

--- a/third_party/gopkgs/github.com/pkg/errors/default.nix
+++ b/third_party/gopkgs/github.com/pkg/errors/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/pkg/errors";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "pkg";
+    repo = "errors";
+    rev = "7f95ac13edff643b8ce5398b6ccab125f8a20c1a";
+    sha256 = "01hfgyxiciqzd9dal7sdskl86a6kpd1flkr7f6v9n6a3xlvlm9s3";
+  };
+}

--- a/third_party/gopkgs/github.com/sirupsen/logrus/default.nix
+++ b/third_party/gopkgs/github.com/sirupsen/logrus/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/sirupsen/logrus";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "sirupsen";
+    repo = "logrus";
+    rev = "67a7fdcf741f4d5cee82cb9800994ccfd4393ad0";
+    sha256 = "0wk9zgfm4m4yf3spgxkwxzsj15qxna9pjdn1hnc1n40zwvmz2204";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."golang.org".x.sys.unix
+  ];
+}

--- a/third_party/gopkgs/github.com/spf13/cobra/default.nix
+++ b/third_party/gopkgs/github.com/spf13/cobra/default.nix
@@ -1,0 +1,15 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/spf13/cobra";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "spf13";
+    repo = "cobra";
+    rev = "b04b5bfc50cbb6c036d2115ed55ea1bccdaf82a9";
+    sha256 = "0kndfiyb9y1vczlwi8q5c2mxsh2jliggy2cb6bb2dqvv8x8s2crk";
+  };
+
+  deps = with pkgs.third_party; map (p: p.gopkg) [
+    gopkgs."github.com".spf13.pflag
+  ];
+}

--- a/third_party/gopkgs/github.com/spf13/pflag/default.nix
+++ b/third_party/gopkgs/github.com/spf13/pflag/default.nix
@@ -1,0 +1,11 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "github.com/spf13/pflag";
+  src = pkgs.third_party.fetchFromGitHub {
+    owner = "spf13";
+    repo = "pflag";
+    rev = "2e9d26c8c37aae03e3f9d4e90b7116f5accb7cab";
+    sha256 = "0gpmacngd0gpslnbkzi263f5ishigzgh6pbdv9hp092rnjl4nd31";
+  };
+}

--- a/third_party/gopkgs/golang.org/x/sync/default.nix
+++ b/third_party/gopkgs/golang.org/x/sync/default.nix
@@ -1,0 +1,9 @@
+{ pkgs, ... }:
+
+pkgs.buildGo.external {
+  path = "golang.org/x/sync";
+  src = builtins.fetchGit {
+    url = "https://go.googlesource.com/sync";
+    rev = "cd5d95a43a6e21273425c7ae415d3df9ea832eeb";
+  };
+}

--- a/third_party/gopkgs/golang.org/x/sys/default.nix
+++ b/third_party/gopkgs/golang.org/x/sys/default.nix
@@ -6,7 +6,4 @@ pkgs.buildGo.external {
     url = "https://go.googlesource.com/sys";
     rev = "ac6580df4449443a05718fd7858c1f91ad5f8d20";
   };
-
-  deps = with pkgs.third_party; [
-  ];
 }

--- a/tools/bin/__dispatch.sh
+++ b/tools/bin/__dispatch.sh
@@ -31,6 +31,9 @@ case "${TARGET_TOOL}" in
   rink)
     attr="third_party.rink"
     ;;
+  pack)
+    attr="third_party.pack"
+    ;;
   *)
     echo "The tool '${TARGET_TOOL}' is currently not installed in this repository."
     exit 1


### PR DESCRIPTION
This imports said library as well as an enormous amount of dependencies for it. I did these manually to scope out how `buildGo.external` performs in a real-world use-case.

The good news is that everything Just Works(tm), the bad news is that with this amount of dependencies for any trivial package it is quite annoying to maintain without automation.

However introducing automation leads to other issues again, because if there's too *little* friction in adding dependencies people do it a lot more. This breaks down however if the friction is on *consuming* the dependencies, not on *adding* them, hmm ...

-----------

Anyways, trailing off topic: The point of this PR is to install buildpacks/pack, so that I can test https://github.com/google/nixery/pull/81