### PR TITLE
Add override function to run Nix-built Emacs configuration with external Emacs

### DIFF
--- a/tools/emacs/default.nix
+++ b/tools/emacs/default.nix
@@ -64,6 +64,7 @@ let
     rainbow-delimiters
     refine
     restclient
+    request
     sly
     string-edit
     swiper

--- a/tools/emacs/default.nix
+++ b/tools/emacs/default.nix
@@ -101,4 +101,16 @@ in lib.fix(self: l: f: third_party.writeShellScriptBin "tazjins-emacs" ''
     # Call withLocalConfig with the path to a *folder* containing a
     # `local.el` which provides local system configuration.
     withLocalConfig = confDir: self confDir f;
+
+    # Build a derivation that uses the specified local Emacs (i.e.
+    # built outside of Nix) instead
+    withLocalEmacs = emacsBin: third_party.writeShellScriptBin "tazjins-emacs" ''
+      exec ${emacsBin} \
+        --debug-init \
+        --no-site-file \
+        --no-init-file \
+        --directory ${(tazjinsEmacs f).deps}/share/emacs/site-lisp \
+        --directory ${./config} ${if l != null then "--directory ${l}" else ""} \
+        --eval "(require 'init)" $@
+    '';
   }) null identity


### PR DESCRIPTION
Say you're on a non-NixOS system and need to run this Emacs configuration, but without using an Emacs from Nix, building ...

```nix
tools.emacs.withLocalEmacs "/usr/bin/emacs"
```

... will create a derivation that does exactly that.